### PR TITLE
Add fzf settings to zsh config

### DIFF
--- a/config/vim/init.vim
+++ b/config/vim/init.vim
@@ -3,7 +3,7 @@
 """"""""""""""""""""""""""""""""""""""""""""""""
 " Plugins (specific to vim-plug):
 "     Install: ':PlugInstall'
-"     Remove unused: 'PlugClean'
+"     Remove unused: ':PlugClean'
 "
 " Language Server
 "     Information on currently running server: ':LspStatus'

--- a/config/zsh/zsh.local
+++ b/config/zsh/zsh.local
@@ -8,8 +8,7 @@ export CONAN_COLOR_DARK=1
 alias bat="batcat"
 export BAT_THEME="Solarized (light)"
 
-export FZF_DEFAULT_COMMAND='find .'
-[ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
+export FZF_DEFAULT_OPTS="--layout=reverse --border --preview 'batcat --style=numbers --color=always {}'"
 
 source /usr/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
 


### PR DESCRIPTION
The previous settings file seems to be lost (most likely due to the rm -rf / accident...). For now it seems to me sufficient to have simple settings directly inside the `zsh.local`.